### PR TITLE
Loosen lifetime on `Memory.regions`

### DIFF
--- a/src/standard_nodes.rs
+++ b/src/standard_nodes.rs
@@ -250,9 +250,9 @@ pub struct Memory<'b, 'a: 'b> {
     pub(crate) node: FdtNode<'b, 'a>,
 }
 
-impl Memory<'_, '_> {
+impl<'a> Memory<'_, 'a> {
     /// Returns an iterator over all of the available memory regions
-    pub fn regions(&self) -> impl Iterator<Item = MemoryRegion> + '_ {
+    pub fn regions(&self) -> impl Iterator<Item = MemoryRegion> + 'a {
         self.node.reg().unwrap()
     }
 


### PR DESCRIPTION
The current lifetime suggests that the returned iterator references the `Memory` itself, but it only references the `Fdt`.