### PR TITLE
Handle `ranges` properties with an `#address-cells` of `3`

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -187,9 +187,9 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
                 let mut stream = FdtData::new(prop.value);
                 ranges = Some(core::iter::from_fn(move || {
                     let (child_bus_address_hi, child_bus_address) = match sizes.address_cells {
-                        1 => (None, stream.u32()?.get() as usize),
-                        2 => (None, stream.u64()?.get() as usize),
-                        3 => (Some(stream.u32()?.get()), stream.u64()?.get() as usize),
+                        1 => (0, stream.u32()?.get() as usize),
+                        2 => (0, stream.u64()?.get() as usize),
+                        3 => (stream.u32()?.get(), stream.u64()?.get() as usize),
                         _ => return None,
                     };
 

--- a/src/standard_nodes.rs
+++ b/src/standard_nodes.rs
@@ -340,6 +340,8 @@ pub struct MemoryRegion {
 pub struct MemoryRange {
     /// Starting address on child bus
     pub child_bus_address: usize,
+    /// The high bits of the child bus' starting address, if present
+    pub child_bus_address_hi: Option<u32>,
     /// Starting address on parent bus
     pub parent_bus_address: usize,
     /// Size of range

--- a/src/standard_nodes.rs
+++ b/src/standard_nodes.rs
@@ -341,7 +341,7 @@ pub struct MemoryRange {
     /// Starting address on child bus
     pub child_bus_address: usize,
     /// The high bits of the child bus' starting address, if present
-    pub child_bus_address_hi: Option<u32>,
+    pub child_bus_address_hi: u32,
     /// Starting address on parent bus
     pub parent_bus_address: usize,
     /// Size of range

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -62,14 +62,16 @@ fn parses_populated_ranges() {
         ranges,
         &[
             MemoryRange {
-                child_bus_address: 0x100_0000_0000_0000,
-                parent_bus_address: 0x0,
-                size: 0x300_0000_0000_0000
+                child_bus_address: 0x0000_0000_0000_0000,
+                child_bus_address_hi: 0x0100_0000,
+                parent_bus_address: 0x3000000,
+                size: 0x10000,
             },
             MemoryRange {
-                child_bus_address: 0x1_0000_0200_0000,
+                child_bus_address: 0x40000000,
+                child_bus_address_hi: 0x2000000,
                 parent_bus_address: 0x4000_0000,
-                size: 0x4000_0000
+                size: 0x4000_0000,
             }
         ]
     );


### PR DESCRIPTION
The `ranges` properties of nodes for PCI hosts use 3 cells to encode a PCI address as the child bus. This adds support for that by using the `#address-cells` of the parent node for the parent bus, and the current node's for the child bus. I've tested this on QEMU's device tree and it seems to produce the correct results.

I'm not sure if the representation of the potential-extra bits in `MemoryRange` is ideal - please let me know if you'd prefer it to be represented in a different way.