### PR TITLE
Add way to pretty-print individual nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ mod pretty_print;
 
 use node::MemoryReservation;
 use parsing::{BigEndianU32, CStr, FdtData};
-use standard_nodes::{Aliases, Chosen, Cpu, Memory, MemoryRegion, MemoryRange, Root};
+use standard_nodes::{Aliases, Chosen, Cpu, Memory, MemoryRange, MemoryRegion, Root};
 
 /// Possible errors when attempting to create an `Fdt`
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!     }
 //!
 //!     if let Some(stdout) = chosen.stdout() {
-//!         println!("It would write stdout to: {}", stdout.name);
+//!         println!("It would write stdout to: {}", stdout.node().name);
 //!     }
 //!
 //!     let soc = fdt.find_node("/soc");

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     parsing::{BigEndianU32, BigEndianU64, CStr, FdtData},
-    standard_nodes::{Compatible, MemoryRegion, MemoryRange},
+    standard_nodes::{Compatible, MemoryRange, MemoryRegion},
     Fdt,
 };
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -39,6 +39,14 @@ pub struct FdtNode<'b, 'a: 'b> {
     parent_props: Option<&'a [u8]>,
 }
 
+#[cfg(feature = "pretty-printing")]
+impl core::fmt::Display for FdtNode<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        crate::pretty_print::print_node(f, *self, 0)?;
+        Ok(())
+    }
+}
+
 impl<'b, 'a: 'b> FdtNode<'b, 'a> {
     fn new(
         name: &'a str,


### PR DESCRIPTION
Fixes #17 

I used the `Display` impl here, which introduces inconsistencies because `Fdt` is pretty-printed with the `Debug` impl.
As I said in #18 , I am of the opinion that pretty-printing should happen in the `Display` impl, but I'll wait for feedback from the original author on the wanted direction here