### PR TITLE
Remove superfluous transparent types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ mod pretty_print;
 
 use node::MemoryReservation;
 use parsing::{BigEndianU32, CStr, FdtData};
-use standard_nodes::{Aliases, Chosen, Cpu, Memory, MemoryRegion, MemoryRange, Root};
+use standard_nodes::{Aliases, Chosen, Cpu, Memory, MemoryRange, MemoryRegion, Root};
 
 /// Possible errors when attempting to create an `Fdt`
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!     }
 //!
 //!     if let Some(stdout) = chosen.stdout() {
-//!         println!("It would write stdout to: {}", stdout.name);
+//!         println!("It would write stdout to: {}", stdout.node().name);
 //!     }
 //!
 //!     let soc = fdt.find_node("/soc");

--- a/src/node.rs
+++ b/src/node.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     parsing::{BigEndianU32, BigEndianU64, CStr, FdtData},
-    standard_nodes::{Compatible, MemoryRegion, MemoryRange},
+    standard_nodes::{Compatible, MemoryRange, MemoryRegion},
     Fdt,
 };
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -21,32 +21,12 @@ impl<'a> CStr<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-#[repr(transparent)]
-pub struct BigEndianU32(u32);
-
-impl BigEndianU32 {
-    pub fn get(self) -> u32 {
-        self.0
-    }
-
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        Some(BigEndianU32(u32::from_be_bytes(bytes.get(..4)?.try_into().unwrap())))
-    }
+pub fn u32_from_be_byte_slice(bytes: &[u8]) -> Option<u32> {
+    Some(u32::from_be_bytes(bytes.get(..4)?.try_into().unwrap()))
 }
 
-#[derive(Debug, Clone, Copy)]
-#[repr(transparent)]
-pub struct BigEndianU64(u64);
-
-impl BigEndianU64 {
-    pub fn get(&self) -> u64 {
-        self.0
-    }
-
-    pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        Some(BigEndianU64(u64::from_be_bytes(bytes.get(..8)?.try_into().unwrap())))
-    }
+pub fn u64_from_be_byte_slice(bytes: &[u8]) -> Option<u64> {
+    Some(u64::from_be_bytes(bytes.get(..8)?.try_into().unwrap()))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -59,15 +39,15 @@ impl<'a> FdtData<'a> {
         Self { bytes }
     }
 
-    pub fn u32(&mut self) -> Option<BigEndianU32> {
-        let ret = BigEndianU32::from_bytes(self.bytes)?;
+    pub fn u32(&mut self) -> Option<u32> {
+        let ret = u32_from_be_byte_slice(self.bytes)?;
         self.skip(4);
 
         Some(ret)
     }
 
-    pub fn u64(&mut self) -> Option<BigEndianU64> {
-        let ret = BigEndianU64::from_bytes(self.bytes)?;
+    pub fn u64(&mut self) -> Option<u64> {
+        let ret = u64_from_be_byte_slice(self.bytes)?;
         self.skip(8);
 
         Some(ret)
@@ -81,7 +61,7 @@ impl<'a> FdtData<'a> {
         self.bytes
     }
 
-    pub fn peek_u32(&self) -> Option<BigEndianU32> {
+    pub fn peek_u32(&self) -> Option<u32> {
         Self::new(self.remaining()).u32()
     }
 
@@ -90,7 +70,7 @@ impl<'a> FdtData<'a> {
     }
 
     pub fn skip_nops(&mut self) {
-        while let Some(crate::node::FDT_NOP) = self.peek_u32().map(|n| n.get()) {
+        while let Some(crate::node::FDT_NOP) = self.peek_u32() {
             let _ = self.u32();
         }
     }

--- a/src/standard_nodes.rs
+++ b/src/standard_nodes.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     node::{CellSizes, FdtNode, NodeProperty},
-    parsing::{BigEndianU32, BigEndianU64, CStr, FdtData},
+    parsing::{u32_from_be_byte_slice, u64_from_be_byte_slice, CStr, FdtData},
     Fdt,
 };
 
@@ -178,8 +178,8 @@ impl<'b, 'a: 'b> Cpu<'b, 'a> {
             .find(|p| p.name == "clock-frequency")
             .or_else(|| self.parent.property("clock-frequency"))
             .map(|p| match p.value.len() {
-                4 => BigEndianU32::from_bytes(p.value).unwrap().get() as usize,
-                8 => BigEndianU64::from_bytes(p.value).unwrap().get() as usize,
+                4 => u32_from_be_byte_slice(p.value).unwrap() as usize,
+                8 => u64_from_be_byte_slice(p.value).unwrap() as usize,
                 _ => unreachable!(),
             })
             .expect("clock-frequency is a required property of cpu nodes")
@@ -192,8 +192,8 @@ impl<'b, 'a: 'b> Cpu<'b, 'a> {
             .find(|p| p.name == "timebase-frequency")
             .or_else(|| self.parent.property("timebase-frequency"))
             .map(|p| match p.value.len() {
-                4 => BigEndianU32::from_bytes(p.value).unwrap().get() as usize,
-                8 => BigEndianU64::from_bytes(p.value).unwrap().get() as usize,
+                4 => u32_from_be_byte_slice(p.value).unwrap() as usize,
+                8 => u64_from_be_byte_slice(p.value).unwrap() as usize,
                 _ => unreachable!(),
             })
             .expect("timebase-frequency is a required property of cpu nodes")
@@ -222,8 +222,8 @@ impl<'a> CpuIds<'a> {
     /// The first listed CPU ID, which will always exist
     pub fn first(self) -> usize {
         match self.address_cells {
-            1 => BigEndianU32::from_bytes(self.reg.value).unwrap().get() as usize,
-            2 => BigEndianU64::from_bytes(self.reg.value).unwrap().get() as usize,
+            1 => u32_from_be_byte_slice(self.reg.value).unwrap() as usize,
+            2 => u64_from_be_byte_slice(self.reg.value).unwrap() as usize,
             n => panic!("address-cells of size {} is currently not supported", n),
         }
     }
@@ -234,8 +234,8 @@ impl<'a> CpuIds<'a> {
         core::iter::from_fn(move || match vals.remaining() {
             [] => None,
             _ => Some(match self.address_cells {
-                1 => vals.u32()?.get() as usize,
-                2 => vals.u64()?.get() as usize,
+                1 => vals.u32()? as usize,
+                2 => vals.u64()? as usize,
                 n => panic!("address-cells of size {} is currently not supported", n),
             }),
         })
@@ -303,9 +303,9 @@ impl<'a> Memory<'_, 'a> {
             let size = stream.u32().expect("size");
 
             mapped_area = Some(MappedArea {
-                effective_address: effective_address.get() as usize,
-                physical_address: physical_address.get() as usize,
-                size: size.get() as usize,
+                effective_address: effective_address as usize,
+                physical_address: physical_address as usize,
+                size: size as usize,
             });
         }
 


### PR DESCRIPTION
`BigEndianU32` and `BigEndianU64` do not actually store their inner types in big endian, but in native endian, and are therefore superfluous. Removing them simplifies the code a bit