### PR TITLE
parsing: remove potential panics

### DIFF
--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -31,7 +31,7 @@ impl BigEndianU32 {
     }
 
     pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        Some(BigEndianU32(u32::from_be_bytes(bytes.get(..4)?.try_into().unwrap())))
+        Some(BigEndianU32(u32::from_be_bytes(bytes.get(..4)?.try_into().ok()?)))
     }
 }
 
@@ -45,7 +45,7 @@ impl BigEndianU64 {
     }
 
     pub(crate) fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        Some(BigEndianU64(u64::from_be_bytes(bytes.get(..8)?.try_into().unwrap())))
+        Some(BigEndianU64(u64::from_be_bytes(bytes.get(..8)?.try_into().ok()?)))
     }
 }
 


### PR DESCRIPTION
Removes the `unwrap` calls in `BigEndian*::from_bytes` implementations.

Currently, the implementation will never panic on the `unwrap` call, because the prior `get` call always returns the appropriate length byte slice.

However, it is safer to call `.ok()?` to bubble-up the `None` result. Which, again, will never be returned with the current implementation. The function will bubble-up `None` on the `get` call before reaching the `try_into`.