### PR TITLE
node: property string list helper

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -550,6 +550,16 @@ impl<'a> NodeProperty<'a> {
         core::str::from_utf8(self.value).map(|s| s.trim_end_matches('\0')).ok()
     }
 
+    /// Attempts to parse the property value as a list of [`&str`].
+    pub fn iter_str(self) -> impl Iterator<Item = &'a str> + 'a {
+        let mut s = self.as_str().map(|s| s.split('\0'));
+
+        core::iter::from_fn(move || match s.as_mut() {
+            Some(s) => s.next(),
+            None => None,
+        })
+    }
+
     fn parse(stream: &mut FdtData<'a>, header: &Fdt<'a>) -> Self {
         match stream.u32().unwrap().get() {
             FDT_PROP => {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -271,3 +271,17 @@ fn interrupt_cells() {
     std::println!("{:?}", uart.parent_interrupt_cells());
     assert_eq!(uart.interrupts().unwrap().collect::<std::vec::Vec<_>>(), std::vec![0xA]);
 }
+
+#[test]
+fn property_str_list() {
+    let fdt = Fdt::new(TEST).unwrap();
+    let test = fdt.find_node("/soc/test").unwrap();
+    let expected = ["sifive,test1", "sifive,test0", "syscon"];
+    let compat = test.property("compatible").unwrap();
+
+    assert_eq!(compat.iter_str().count(), expected.len());
+
+    test.property("compatible").unwrap().iter_str().zip(expected).for_each(|(prop, exp)| {
+        assert_eq!(prop, exp);
+    });
+}


### PR DESCRIPTION
Adds a helper function to convert a `NodeProperty` value into a list of `&str`.