### PR TITLE
node: add `iter_cell_size` and `iter_prop_encoded` helpers

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -371,6 +371,98 @@ impl Default for CellSizes {
     }
 }
 
+/// Represents the cell size of a property value.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CellSize {
+    None = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+}
+
+impl CellSize {
+    /// Creates a new [CellSize].
+    pub const fn new() -> Self {
+        Self::One
+    }
+
+    /// Infallible function that converts a [`u8`] into a [CellSize].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
+            1 => Self::One,
+            2 => Self::Two,
+            3 => Self::Three,
+            _ => Self::None,
+        }
+    }
+
+    /// Converts a [CellSize] into a [`u8`].
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl From<u8> for CellSize {
+    fn from(val: u8) -> Self {
+        Self::from_u8(val)
+    }
+}
+
+impl From<u16> for CellSize {
+    fn from(val: u16) -> Self {
+        Self::from_u8(val as u8)
+    }
+}
+
+impl From<u32> for CellSize {
+    fn from(val: u32) -> Self {
+        Self::from_u8(val as u8)
+    }
+}
+
+impl From<u64> for CellSize {
+    fn from(val: u64) -> Self {
+        Self::from_u8(val as u8)
+    }
+}
+
+impl From<usize> for CellSize {
+    fn from(val: usize) -> Self {
+        Self::from_u8(val as u8)
+    }
+}
+
+impl From<CellSize> for u8 {
+    fn from(val: CellSize) -> Self {
+        val.to_u8() as Self
+    }
+}
+
+impl From<CellSize> for u16 {
+    fn from(val: CellSize) -> Self {
+        val.to_u8() as Self
+    }
+}
+
+impl From<CellSize> for u32 {
+    fn from(val: CellSize) -> Self {
+        val.to_u8() as Self
+    }
+}
+
+impl From<CellSize> for u64 {
+    fn from(val: CellSize) -> Self {
+        val.to_u8() as Self
+    }
+}
+
+impl From<CellSize> for usize {
+    fn from(val: CellSize) -> Self {
+        val.to_u8() as Self
+    }
+}
+
 /// A raw `reg` property value set
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RawReg<'a> {
@@ -546,12 +638,12 @@ impl<'a> NodeProperty<'a> {
     }
 
     /// Attempts to parse the property value as a list of [`usize`].
-    pub fn iter_cell_size(self, cell_size: usize) -> impl Iterator<Item = u64> + 'a {
+    pub fn iter_cell_size(self, cell_size: CellSize) -> impl Iterator<Item = u64> + 'a {
         let mut cells = FdtData::new(self.value);
 
         core::iter::from_fn(move || match cell_size {
-            1 => Some(cells.u32()?.get() as u64),
-            2 => Some(cells.u64()?.get()), 
+            CellSize::One => Some(cells.u32()?.get() as u64),
+            CellSize::Two => Some(cells.u64()?.get()),
             _ => None,
         })
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -545,6 +545,17 @@ impl<'a> NodeProperty<'a> {
         }
     }
 
+    /// Attempts to parse the property value as a list of [`usize`].
+    pub fn iter_cell_size(self, cell_size: usize) -> impl Iterator<Item = u64> + 'a {
+        let mut cells = FdtData::new(self.value);
+
+        core::iter::from_fn(move || match cell_size {
+            1 => Some(cells.u32()?.get() as u64),
+            2 => Some(cells.u64()?.get()), 
+            _ => None,
+        })
+    }
+
     /// Attempt to parse the property value as a `&str`
     pub fn as_str(self) -> Option<&'a str> {
         core::str::from_utf8(self.value).map(|s| s.trim_end_matches('\0')).ok()

--- a/src/node.rs
+++ b/src/node.rs
@@ -150,7 +150,7 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
     /// an `#address-cells` value of 3.
     pub fn reg(self) -> Option<impl Iterator<Item = crate::MemoryRegion> + 'a> {
         let sizes = self.parent_cell_sizes();
-        if sizes.address_cells > 2 || sizes.size_cells > 2 {
+        if usize::from(sizes.address_cells) > 2 || usize::from(sizes.size_cells) > 2 {
             return None;
         }
 
@@ -160,15 +160,15 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
                 let mut stream = FdtData::new(prop.value);
                 reg = Some(core::iter::from_fn(move || {
                     let starting_address = match sizes.address_cells {
-                        1 => stream.u32()?.get() as usize,
-                        2 => stream.u64()?.get() as usize,
+                        CellSize::One => stream.u32()?.get() as usize,
+                        CellSize::Two => stream.u64()?.get() as usize,
                         _ => return None,
                     } as *const u8;
 
                     let size = match sizes.size_cells {
-                        0 => None,
-                        1 => Some(stream.u32()?.get() as usize),
-                        2 => Some(stream.u64()?.get() as usize),
+                        CellSize::None => None,
+                        CellSize::One => Some(stream.u32()?.get() as usize),
+                        CellSize::Two => Some(stream.u64()?.get() as usize),
                         _ => return None,
                     };
 
@@ -185,7 +185,7 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
         let sizes = self.cell_sizes();
         let parent_sizes = self.parent_cell_sizes();
 
-        if sizes.address_cells > 3 || sizes.size_cells > 2 || parent_sizes.size_cells > 2 {
+        if usize::from(sizes.address_cells) > 3 || usize::from(sizes.size_cells) > 2 || usize::from(parent_sizes.size_cells) > 2 {
             return None;
         }
 
@@ -195,21 +195,21 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
                 let mut stream = FdtData::new(prop.value);
                 ranges = Some(core::iter::from_fn(move || {
                     let (child_bus_address_hi, child_bus_address) = match sizes.address_cells {
-                        1 => (0, stream.u32()?.get() as usize),
-                        2 => (0, stream.u64()?.get() as usize),
-                        3 => (stream.u32()?.get(), stream.u64()?.get() as usize),
+                        CellSize::One => (0, stream.u32()?.get() as usize),
+                        CellSize::Two => (0, stream.u64()?.get() as usize),
+                        CellSize::Three => (stream.u32()?.get(), stream.u64()?.get() as usize),
                         _ => return None,
                     };
 
                     let parent_bus_address = match parent_sizes.address_cells {
-                        1 => stream.u32()?.get() as usize,
-                        2 => stream.u64()?.get() as usize,
+                        CellSize::One => stream.u32()?.get() as usize,
+                        CellSize::Two => stream.u64()?.get() as usize,
                         _ => return None,
                     };
 
                     let size = match sizes.size_cells {
-                        1 => stream.u32()?.get() as usize,
-                        2 => stream.u64()?.get() as usize,
+                        CellSize::One => stream.u32()?.get() as usize,
+                        CellSize::Two => stream.u64()?.get() as usize,
                         _ => return None,
                     };
 
@@ -236,8 +236,8 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
             let mut stream = FdtData::new(prop.value);
             return Some(core::iter::from_fn(move || {
                 Some(RawReg {
-                    address: stream.take(sizes.address_cells * 4)?,
-                    size: stream.take(sizes.size_cells * 4)?,
+                    address: stream.take(usize::from(sizes.address_cells) * 4)?,
+                    size: stream.take(usize::from(sizes.size_cells) * 4)?,
                 })
             }));
         }
@@ -266,12 +266,12 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
                 "#address-cells" => {
                     cell_sizes.address_cells = BigEndianU32::from_bytes(property.value)
                         .expect("not enough bytes for #address-cells value")
-                        .get() as usize;
+                        .get().into();
                 }
                 "#size-cells" => {
                     cell_sizes.size_cells = BigEndianU32::from_bytes(property.value)
                         .expect("not enough bytes for #size-cells value")
-                        .get() as usize;
+                        .get().into();
                 }
                 _ => {}
             }
@@ -357,17 +357,27 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
 }
 
 /// The number of cells (big endian u32s) that addresses and sizes take
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct CellSizes {
     /// Size of values representing an address
-    pub address_cells: usize,
+    pub address_cells: CellSize,
     /// Size of values representing a size
-    pub size_cells: usize,
+    pub size_cells: CellSize,
+}
+
+impl CellSizes {
+    /// Creates a new [CellSizes].
+    pub const fn new() -> Self {
+        Self {
+            address_cells: CellSize::Two,
+            size_cells: CellSize::One,
+        }
+    }
 }
 
 impl Default for CellSizes {
     fn default() -> Self {
-        CellSizes { address_cells: 2, size_cells: 1 }
+        Self::new()
     }
 }
 
@@ -637,7 +647,7 @@ impl<'a> NodeProperty<'a> {
         }
     }
 
-    /// Attempts to parse the property value as a list of [`usize`].
+    /// Attempts to parse the property value as a list of [`u64`].
     pub fn iter_cell_size(self, cell_size: CellSize) -> impl Iterator<Item = u64> + 'a {
         let mut cells = FdtData::new(self.value);
 

--- a/src/standard_nodes.rs
+++ b/src/standard_nodes.rs
@@ -159,7 +159,7 @@ pub struct Cpu<'b, 'a: 'b> {
 impl<'b, 'a: 'b> Cpu<'b, 'a> {
     /// Return the IDs for the given CPU
     pub fn ids(self) -> CpuIds<'a> {
-        let address_cells = self.node.parent_cell_sizes().address_cells;
+        let address_cells = usize::from(self.node.parent_cell_sizes().address_cells);
 
         CpuIds {
             reg: self

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -286,3 +286,18 @@ fn property_cell_size_list() {
     std::println!("{int_map_mask_list:?}");
     assert_eq!(int_map_mask_list, std::vec![0x1800, 0x00, 0x00, 0x07]);
 }
+
+#[test]
+fn property_prop_encoded_list() {
+    let fdt = Fdt::new(TEST).unwrap();
+    let node = fdt.find_node("/soc/rtc").unwrap();
+
+    let int_map_mask_list = node
+        .property("reg")
+        .unwrap()
+        .iter_prop_encoded(node.parent_cell_sizes())
+        .collect::<std::vec::Vec<(u64, u64)>>();
+
+    std::println!("{int_map_mask_list:?}");
+    assert_eq!(int_map_mask_list, std::vec![(0x101000, 0x1000)]);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -280,7 +280,7 @@ fn property_cell_size_list() {
     let int_map_mask_list = uart
         .property("interrupt-map-mask")
         .unwrap()
-        .iter_cell_size(uart.interrupt_cells().unwrap_or(1))
+        .iter_cell_size(uart.interrupt_cells().unwrap_or(1).into())
         .collect::<std::vec::Vec<u64>>();
 
     std::println!("{int_map_mask_list:?}");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -271,3 +271,18 @@ fn interrupt_cells() {
     std::println!("{:?}", uart.parent_interrupt_cells());
     assert_eq!(uart.interrupts().unwrap().collect::<std::vec::Vec<_>>(), std::vec![0xA]);
 }
+
+#[test]
+fn property_cell_size_list() {
+    let fdt = Fdt::new(TEST).unwrap();
+    let uart = fdt.find_node("/soc/pci").unwrap();
+
+    let int_map_mask_list = uart
+        .property("interrupt-map-mask")
+        .unwrap()
+        .iter_cell_size(uart.interrupt_cells().unwrap_or(1))
+        .collect::<std::vec::Vec<u64>>();
+
+    std::println!("{int_map_mask_list:?}");
+    assert_eq!(int_map_mask_list, std::vec![0x1800, 0x00, 0x00, 0x07]);
+}


### PR DESCRIPTION
Adds a `NodeProperty::as_usize_list` helper function to parse the property value as a `usize` list.