### PR TITLE
node: avoid runtime panic

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -71,7 +71,7 @@ impl<'b, 'a: 'b> FdtNode<'b, 'a> {
                 stream.skip(4);
             }
 
-            if stream.peek_u32().unwrap().get() == FDT_PROP {
+            if stream.peek_u32()?.get() == FDT_PROP {
                 Some(NodeProperty::parse(&mut stream, self.header))
             } else {
                 done = true;


### PR DESCRIPTION
Bubble up a `None` value instead of `panic`ing by calling `unwrap`.