### PR TITLE
fix(pretty_print): print strings with whitespaces

### DIFF
--- a/src/pretty_print.rs
+++ b/src/pretty_print.rs
@@ -48,10 +48,7 @@ pub fn print_node(
                 )?;
             }
             _ => match prop.as_str() {
-                Some(value)
-                    if (!value.is_empty() && value.chars().all(|c| c.is_ascii_graphic()))
-                        || prop.value == [0] =>
-                {
+                Some(value) if !value.is_empty() => {
                     writeln!(f, "{:width$}{} = {:?}", ' ', prop.name, value, width = n_spaces + 4)?
                 }
                 _ => match prop.value.len() {


### PR DESCRIPTION
Thanks for this crate! :)

This PR fixes pretty printing of strings containing whitespaces (such as in bootargs).

This was broken, because `' '.is_ascii_graphic() = false`.

`prop.value == [0]` is redundant with `s.trim_end_matches('\0')` in `NodeProperty::as_str`.