### PR TITLE
Improve InterruptSpecifier api

### DIFF
--- a/src/properties/interrupts.rs
+++ b/src/properties/interrupts.rs
@@ -56,12 +56,8 @@ impl<'a, P: ParserWithMode<'a>> LegacyInterrupts<'a, P> {
     }
 
     #[allow(missing_docs)]
-    pub fn iter<I: CellCollector>(self) -> LegacyInterruptsIter<'a, I> {
-        LegacyInterruptsIter {
-            interrupt_cells: self.interrupt_cells,
-            encoded_array: self.encoded_array,
-            _collector: core::marker::PhantomData,
-        }
+    pub fn iter(self) -> LegacyInterruptsIter<'a> {
+        LegacyInterruptsIter { interrupt_cells: self.interrupt_cells, encoded_array: self.encoded_array }
     }
 }
 
@@ -101,30 +97,16 @@ impl<'a, P: ParserWithMode<'a>> Clone for LegacyInterrupts<'a, P> {
 }
 
 #[allow(missing_docs)]
-pub struct LegacyInterruptsIter<'a, I: CellCollector> {
+pub struct LegacyInterruptsIter<'a> {
     interrupt_cells: InterruptCells,
     encoded_array: &'a [u8],
-    _collector: core::marker::PhantomData<*mut I>,
 }
 
-impl<'a, I: CellCollector> Iterator for LegacyInterruptsIter<'a, I> {
-    type Item = Result<I::Output, CollectCellsError>;
+impl<'a> Iterator for LegacyInterruptsIter<'a> {
+    type Item = InterruptSpecifier<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        let encoded_specifier = self.encoded_array.get(..self.interrupt_cells.as_byte_count())?;
-        let mut specifier_collector = <I as CellCollector>::Builder::default();
-
-        for encoded_specifier in encoded_specifier.chunks_exact(4) {
-            // TODO: replace this stuff with `array_chunks` when its stabilized
-            //
-            // These unwraps can't panic because `chunks_exact` guarantees that
-            // we'll always get slices of 4 bytes
-            if let Err(e) = specifier_collector.push(u32::from_be_bytes(encoded_specifier.try_into().unwrap())) {
-                return Some(Err(e));
-            }
-        }
-
-        self.encoded_array = self.encoded_array.get(self.interrupt_cells.as_byte_count()..)?;
-        Some(Ok(I::map(specifier_collector.finish())))
+        let encoded_array = self.encoded_array.split_off(..self.interrupt_cells.as_byte_count())?;
+        Some(InterruptSpecifier { interrupt_cells: self.interrupt_cells, encoded_array })
     }
 }
 
@@ -246,7 +228,7 @@ impl<'a, P: ParserWithMode<'a>> ExtendedInterrupt<'a, P> {
     }
 }
 
-/// An individual interrupt specifier from an [`ExtendedInterrupt`] value.
+/// An individual interrupt specifier from an [`ExtendedInterrupt`] or [`LegacyInterrupts`] value.
 pub struct InterruptSpecifier<'a> {
     interrupt_cells: InterruptCells,
     encoded_array: &'a [u8],
@@ -268,16 +250,6 @@ impl<'a> InterruptSpecifier<'a> {
     /// Iterator over the raw [`u32`] components that comprise this interrupt specifier.
     pub fn iter(self) -> InterruptSpecifierIter<'a> {
         InterruptSpecifierIter { encoded_array: self.encoded_array }
-    }
-
-    /// Iterator over `(u32, u32)` interrupt specifier pairs, if
-    /// `#interrupt-cells` value is `2`.
-    pub fn iter_pairs(self) -> Option<InterruptSpecifierIterPairs<'a>> {
-        if self.interrupt_cells.0 != 2 {
-            return None;
-        }
-
-        Some(InterruptSpecifierIterPairs { encoded_array: self.encoded_array })
     }
 
     /// Extract the single component that comprises the interrupt specifier, if
@@ -330,30 +302,6 @@ impl<'a> Iterator for InterruptSpecifierIter<'a> {
         // This panic can never fail since the slice length is guaranteed to be
         // 4 bytes long
         Some(u32::from_be_bytes(next.try_into().unwrap()))
-    }
-}
-
-/// Iterator over pairs of `u32`s representing an interrupt specifier
-pub struct InterruptSpecifierIterPairs<'a> {
-    encoded_array: &'a [u8],
-}
-
-impl<'a> Iterator for InterruptSpecifierIterPairs<'a> {
-    type Item = (u32, u32);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.encoded_array.is_empty() {
-            return None;
-        }
-
-        let (next, rest) = self.encoded_array.split_at_checked(8)?;
-        self.encoded_array = rest;
-
-        let (first, second) = next.split_at(4);
-
-        // This panic can never fail since the slice length is guaranteed to be
-        // 4 bytes long
-        Some((u32::from_be_bytes(first.try_into().unwrap()), u32::from_be_bytes(second.try_into().unwrap())))
     }
 }
 

--- a/src/properties/interrupts.rs
+++ b/src/properties/interrupts.rs
@@ -106,7 +106,7 @@ impl<'a> Iterator for LegacyInterruptsIter<'a> {
     type Item = InterruptSpecifier<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         let encoded_array = self.encoded_array.split_off(..self.interrupt_cells.as_byte_count())?;
-        Some(InterruptSpecifier { interrupt_cells: self.interrupt_cells, encoded_array })
+        Some(InterruptSpecifier { encoded_array })
     }
 }
 
@@ -224,13 +224,12 @@ impl<'a, P: ParserWithMode<'a>> ExtendedInterrupt<'a, P> {
     }
 
     pub fn interrupt_specifier(self) -> InterruptSpecifier<'a> {
-        InterruptSpecifier { interrupt_cells: self.interrupt_cells, encoded_array: self.encoded_array }
+        InterruptSpecifier { encoded_array: self.encoded_array }
     }
 }
 
 /// An individual interrupt specifier from an [`ExtendedInterrupt`] or [`LegacyInterrupts`] value.
 pub struct InterruptSpecifier<'a> {
-    interrupt_cells: InterruptCells,
     encoded_array: &'a [u8],
 }
 
@@ -255,7 +254,7 @@ impl<'a> InterruptSpecifier<'a> {
     /// Extract the single component that comprises the interrupt specifier, if
     /// the `#interrupt-cells` value is `1`.
     pub fn single(self) -> Option<u32> {
-        if self.interrupt_cells.0 != 1 {
+        if self.encoded_array.len() != 4 {
             return None;
         }
 
@@ -265,7 +264,7 @@ impl<'a> InterruptSpecifier<'a> {
     /// Extract the two components that comprise the interrupt specifier, if the
     /// `#interrupt-cells` value is `2`.
     pub fn pair(self) -> Option<(u32, u32)> {
-        if self.interrupt_cells.0 != 2 {
+        if self.encoded_array.len() != 8 {
             return None;
         }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -437,7 +437,7 @@ fn interrupt_cells() {
         _ => unreachable!(),
     };
 
-    assert_eq!(interrupts.iter::<u32>().collect::<Result<std::vec::Vec<_>, _>>().unwrap(), &[0xA]);
+    assert_eq!(interrupts.iter().map(|interrupt| interrupt.single().unwrap()).collect::<std::vec::Vec<u32>>(), &[0xA]);
 }
 
 #[test]


### PR DESCRIPTION
Return an iterator of it from `LegacyInterrupts::iter` and remove the `iter_pairs` method which is redundant with `pair`.

Fixes https://github.com/repnop/fdt/issues/52
Fixes https://github.com/repnop/fdt/issues/53