### PR TITLE
Fix clippy::chunks_exact_to_as_chunks lint

### DIFF
--- a/src/nodes/cpus.rs
+++ b/src/nodes/cpus.rs
@@ -650,8 +650,8 @@ impl<'a, C: CellCollector> Iterator for CpuIdsIter<'a, C> {
 
         let mut collector = <C as CellCollector>::Builder::default();
 
-        for cell in this_cell.chunks_exact(4) {
-            if let Err(e) = collector.push(u32::from_be_bytes(cell.try_into().unwrap())) {
+        for &cell in this_cell.as_chunks::<4>().0 {
+            if let Err(e) = collector.push(u32::from_be_bytes(cell)) {
                 return Some(Err(e));
             }
         }

--- a/src/nodes/memory.rs
+++ b/src/nodes/memory.rs
@@ -218,8 +218,8 @@ impl<'a, P: ParserWithMode<'a>> ReservedMemoryChild<'a, P> {
 
             let mut builder = <C as CellCollector>::Builder::default();
 
-            for component in size.value.chunks_exact(4) {
-                if builder.push(u32::from_be_bytes(component.try_into().unwrap())).is_err() {
+            for &component in size.value.as_chunks::<4>().0 {
+                if builder.push(u32::from_be_bytes(component)).is_err() {
                     return Ok(Some(Err(CollectCellsError)));
                 }
             }
@@ -251,8 +251,8 @@ impl<'a, P: ParserWithMode<'a>> ReservedMemoryChild<'a, P> {
 
             let mut builder = <C as CellCollector>::Builder::default();
 
-            for component in alignment.value.chunks_exact(4) {
-                if builder.push(u32::from_be_bytes(component.try_into().unwrap())).is_err() {
+            for &component in alignment.value.as_chunks::<4>().0 {
+                if builder.push(u32::from_be_bytes(component)).is_err() {
                     return Ok(Some(Err(CollectCellsError)));
                 }
             }

--- a/src/properties/interrupts.rs
+++ b/src/properties/interrupts.rs
@@ -241,10 +241,10 @@ impl<'a> InterruptSpecifier<'a> {
     /// Attempt to collect the specifier bytes into a specific type.
     pub fn collect_to<C: CellCollector>(self) -> Result<<C as CellCollector>::Output, CollectCellsError> {
         let mut collector = <C as CellCollector>::Builder::default();
-        for chunk in self.encoded_array.chunks_exact(4) {
+        for &chunk in self.encoded_array.as_chunks::<4>().0 {
             // UNWRAP: this unwrap cannot panic because `chunk` is guaranteed to
             // be 4 bytes.
-            collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            collector.push(u32::from_be_bytes(chunk))?;
         }
 
         Ok(C::map(collector.finish()))
@@ -421,18 +421,14 @@ impl<'a, AddrMask: CellCollector, IntMask: CellCollector, P: ParserWithMode<'a>>
 
                 let mut address_collector = AddrMask::Builder::default();
                 let mut specifier_collector = IntMask::Builder::default();
-                let mut cells = prop.value.chunks_exact(4);
+                let mut cells = prop.value.as_chunks::<4>().0.iter();
 
-                // TODO: replace this stuff with `array_chunks` when its stabilized
-                //
-                // These unwraps can't panic because `chunks_exact` guarantees that
-                // we'll always get slices of 4 bytes
-                for chunk in cells.by_ref().take(address_cells.0) {
-                    address_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+                for &chunk in cells.by_ref().take(address_cells.0) {
+                    address_collector.push(u32::from_be_bytes(chunk))?;
                 }
 
-                for chunk in cells.take(interrupt_cells.0) {
-                    specifier_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+                for &chunk in cells.take(interrupt_cells.0) {
+                    specifier_collector.push(u32::from_be_bytes(chunk))?;
                 }
 
                 Ok(Some(Self {
@@ -691,23 +687,23 @@ impl<
             self.encoded_map = rest;
 
             let mut child_address_collector = CAddr::Builder::default();
-            for chunk in child_address_iter.chunks_exact(4) {
-                child_address_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in child_address_iter.as_chunks::<4>().0 {
+                child_address_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let mut child_specifier_collector = CInt::Builder::default();
-            for chunk in child_specifier_iter.chunks_exact(4) {
-                child_specifier_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in child_specifier_iter.as_chunks::<4>().0 {
+                child_specifier_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let mut parent_address_collector = PAddr::Builder::default();
-            for chunk in parent_address_iter.chunks_exact(4) {
-                parent_address_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in parent_address_iter.as_chunks::<4>().0 {
+                parent_address_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let mut parent_specifier_collector = PInt::Builder::default();
-            for chunk in parent_specifier_iter.chunks_exact(4) {
-                parent_specifier_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in parent_specifier_iter.as_chunks::<4>().0 {
+                parent_specifier_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             Ok(Some(InterruptMapEntry {
@@ -807,23 +803,23 @@ where
             self.encoded_map = rest;
 
             let mut child_address_collector = CAddr::Builder::default();
-            for chunk in child_address_iter.chunks_exact(4) {
-                child_address_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in child_address_iter.as_chunks::<4>().0 {
+                child_address_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let mut child_specifier_collector = CInt::Builder::default();
-            for chunk in child_specifier_iter.chunks_exact(4) {
-                child_specifier_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in child_specifier_iter.as_chunks::<4>().0 {
+                child_specifier_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let mut parent_address_collector = PAddr::Builder::default();
-            for chunk in parent_address_iter.chunks_exact(4) {
-                parent_address_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in parent_address_iter.as_chunks::<4>().0 {
+                parent_address_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let mut parent_specifier_collector = PInt::Builder::default();
-            for chunk in parent_specifier_iter.chunks_exact(4) {
-                parent_specifier_collector.push(u32::from_be_bytes(chunk.try_into().unwrap()))?;
+            for &chunk in parent_specifier_iter.as_chunks::<4>().0 {
+                parent_specifier_collector.push(u32::from_be_bytes(chunk))?;
             }
 
             let child_unit_address = CAddr::map(child_address_collector.finish());

--- a/src/properties/ranges.rs
+++ b/src/properties/ranges.rs
@@ -76,34 +76,22 @@ impl<'a, CAddr: CellCollector, PAddr: CellCollector, Len: CellCollector> Iterato
             .get(child_address_bytes + parent_address_bytes..child_address_bytes + parent_address_bytes + len_bytes)?;
 
         let mut child_address_collector = <CAddr as CellCollector>::Builder::default();
-        for encoded_address in child_encoded_address.chunks_exact(4) {
-            // TODO: replace this stuff with `array_chunks` when its stabilized
-            //
-            // These unwraps can't panic because `chunks_exact` guarantees that
-            // we'll always get slices of 4 bytes
-            if let Err(e) = child_address_collector.push(u32::from_be_bytes(encoded_address.try_into().unwrap())) {
+        for &encoded_address in child_encoded_address.as_chunks::<4>().0 {
+            if let Err(e) = child_address_collector.push(u32::from_be_bytes(encoded_address)) {
                 return Some(Err(e));
             }
         }
 
         let mut parent_address_collector = <PAddr as CellCollector>::Builder::default();
-        for encoded_address in parent_encoded_address.chunks_exact(4) {
-            // TODO: replace this stuff with `array_chunks` when its stabilized
-            //
-            // These unwraps can't panic because `chunks_exact` guarantees that
-            // we'll always get slices of 4 bytes
-            if let Err(e) = parent_address_collector.push(u32::from_be_bytes(encoded_address.try_into().unwrap())) {
+        for &encoded_address in parent_encoded_address.as_chunks::<4>().0 {
+            if let Err(e) = parent_address_collector.push(u32::from_be_bytes(encoded_address)) {
                 return Some(Err(e));
             }
         }
 
         let mut len_collector = <Len as CellCollector>::Builder::default();
-        for encoded_len in encoded_len.chunks_exact(4) {
-            // TODO: replace this stuff with `array_chunks` when its stabilized
-            //
-            // These unwraps can't panic because `chunks_exact` guarantees that
-            // we'll always get slices of 4 bytes
-            if let Err(e) = len_collector.push(u32::from_be_bytes(encoded_len.try_into().unwrap())) {
+        for &encoded_len in encoded_len.as_chunks::<4>().0 {
+            if let Err(e) = len_collector.push(u32::from_be_bytes(encoded_len)) {
                 return Some(Err(e));
             }
         }

--- a/src/properties/reg.rs
+++ b/src/properties/reg.rs
@@ -82,23 +82,15 @@ impl<'a, CAddr: CellCollector, Len: CellCollector> Iterator for RegIter<'a, CAdd
         let encoded_len = self.encoded_array.get(address_bytes..address_bytes + size_bytes)?;
 
         let mut address_collector = <CAddr as CellCollector>::Builder::default();
-        for encoded_address in encoded_address.chunks_exact(4) {
-            // TODO: replace this stuff with `array_chunks` when its stabilized
-            //
-            // These unwraps can't panic because `chunks_exact` guarantees that
-            // we'll always get slices of 4 bytes
-            if let Err(e) = address_collector.push(u32::from_be_bytes(encoded_address.try_into().unwrap())) {
+        for &encoded_address in encoded_address.as_chunks::<4>().0 {
+            if let Err(e) = address_collector.push(u32::from_be_bytes(encoded_address)) {
                 return Some(Err(e));
             }
         }
 
         let mut len_collector = <Len as CellCollector>::Builder::default();
-        for encoded_len in encoded_len.chunks_exact(4) {
-            // TODO: replace this stuff with `array_chunks` when its stabilized
-            //
-            // These unwraps can't panic because `chunks_exact` guarantees that
-            // we'll always get slices of 4 bytes
-            if let Err(e) = len_collector.push(u32::from_be_bytes(encoded_len.try_into().unwrap())) {
+        for &encoded_len in encoded_len.as_chunks::<4>().0 {
+            if let Err(e) = len_collector.push(u32::from_be_bytes(encoded_len)) {
                 return Some(Err(e));
             }
         }


### PR DESCRIPTION
This has been newly introduced with 1.98, causing CI to fail.